### PR TITLE
Remove depracated `twophase` keyword in oracle connection manager.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
 ------------------
 
 - Fix bug in oracles upload_blob method for cx_Oracle newer than 5.1.3.
+- Adjust Oracle connection setup, to support newer cx_oracle versions.
 
 
 1.6.3 (2016-09-30)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 ##############################################################################
 """A backend for ZODB that stores pickles in a relational database."""
 
-version = '1.6.4.dev0'
+version = '1.6.3.post1.dev0'
 VERSION = version
 
 # The choices for the Trove Development Status line:


### PR DESCRIPTION
Adjust oracle connection setup, to support newer cx_oracle versions (cx_Oracle 7.3).

The keyword argument `twophase` ist no longer supported, I therefore cherrypicked the changes from  (https://github.com/zodb/relstorage/pull/363). I also tried to cherrypick the `outputtypehelper`, but that doesn't worked.

For [CA-5774](https://4teamwork.atlassian.net/browse/CA-5774)