### PR TITLE
Fix bug in oracles upload_blob method for cx_Oracle newer than 5.1.3.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 1.6.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix bug in oracles upload_blob method for cx_Oracle newer than 5.1.3.
 
 
 1.6.3 (2016-09-30)

--- a/relstorage/adapters/mover.py
+++ b/relstorage/adapters/mover.py
@@ -1369,10 +1369,13 @@ class ObjectMover(object):
                 offset = 1 # Oracle still uses 1-based indexing.
                 for _i in xrange(maxsize / write_chunk_size):
                     write_chunk = f.read(write_chunk_size)
-                    if not blob.write(write_chunk, offset):
-                        # EOF.
+                    if write_chunk:
+                        blob.write(write_chunk, offset)
+                    else:
                         return
+
                     offset += len(write_chunk)
+
                 if blob is not None and blob.isopen():
                     blob.close()
                 chunk_num += 1


### PR DESCRIPTION
Newer versions of cx_oracle no longer return the size of the written chunk, but None (`Py_RETURN_NONE`) instead when successfull (see https://github.com/oracle/python-cx_Oracle/blob/5.3/src/ExternalLobVar.c#L446). With the current implementation of the oracle_upload_blob method, this leads to corrupt files, beacause only the first chunk is uploaded to the db and then it stops.

For https://4teamwork.atlassian.net/browse/CA-5774